### PR TITLE
Use conman to bind hugsql to a dbspec

### DIFF
--- a/resources/leiningen/new/brevity/profiles.clj
+++ b/resources/leiningen/new/brevity/profiles.clj
@@ -3,6 +3,6 @@
                       :port "8080"
                       :session-timeout-minutes "10000"
                       :idle-session-timeout-minutes "15"
-                      :database-url "postgresql://postgres:postgres@localhost:55432/postgres"
+                      :jdbc-database-url "jdbc:postgresql://localhost:55432/postgres?user=postgres&password=postgres"
                       :dev-database "true"
                       :dev-database-port "55432"}}}

--- a/resources/leiningen/new/brevity/project.clj
+++ b/resources/leiningen/new/brevity/project.clj
@@ -27,6 +27,7 @@
                  [migratus "LATEST"]
                  [com.layerware/hugsql "LATEST"]
                  [hugsql-adapter-case "LATEST"]
+                 [conman "LATEST"]
                  [buddy/buddy-auth "LATEST"]
                  [buddy/buddy-sign "LATEST"]
                  [buddy/buddy-hashers "LATEST"]

--- a/resources/leiningen/new/brevity/project.clj
+++ b/resources/leiningen/new/brevity/project.clj
@@ -28,6 +28,7 @@
                  [com.layerware/hugsql "LATEST"]
                  [hugsql-adapter-case "LATEST"]
                  [conman "LATEST"]
+                 [hikari-cp "LATEST"]
                  [buddy/buddy-auth "LATEST"]
                  [buddy/buddy-sign "LATEST"]
                  [buddy/buddy-hashers "LATEST"]

--- a/resources/leiningen/new/brevity/src/brevity/clj/models/sql.clj
+++ b/resources/leiningen/new/brevity/src/brevity/clj/models/sql.clj
@@ -3,18 +3,23 @@
             [environ.core :as environ]
             [hugsql.core :as hug]
             [hugsql-adapter-case.adapters :as adapters]
+            [hikari-cp.core :as hikari]
             [conman.core :as conman])
   (:import [com.opentable.db.postgres.embedded EmbeddedPostgres]
            [java.io File]))
 
-; Brevity doesn't yet do any connection pooling by default.  If you have a need for connection pooling, see:
-; https://github.com/luminus-framework/conman#using-bind-connection
-(def dbspec (environ/env :database-url))
+(def connection-uri (environ/env :jdbc-database-url))
+
+(def dbspec
+  (delay {:datasource (hikari/make-datasource
+                        {:jdbc-url connection-uri
+                         :maximum-pool-size (or (environ/env :hikari-maximum-pool-size) 10)
+                         :minimum-idle (or (environ/env :hikari-minimum-idle) 10)})}))
 
 (hug/set-adapter! (adapters/kebab-adapter))
 
-(conman/bind-connection dbspec "{{raw-name}}/sql/articles.sql")
-(conman/bind-connection dbspec "{{raw-name}}/sql/users.sql")
+(conman/bind-connection @dbspec "brevitytestproject/sql/articles.sql")
+(conman/bind-connection @dbspec "brevitytestproject/sql/users.sql")
 
 (defn init! []
       (let [dev-mode? (= "true" (environ/env :dev-database))]

--- a/resources/leiningen/new/brevity/src/brevity/clj/models/sql.clj
+++ b/resources/leiningen/new/brevity/src/brevity/clj/models/sql.clj
@@ -2,16 +2,19 @@
   (:require [clojure.java.jdbc :as jdbc]
             [environ.core :as environ]
             [hugsql.core :as hug]
-            [hugsql-adapter-case.adapters :as adapters])
+            [hugsql-adapter-case.adapters :as adapters]
+            [conman.core :as conman])
   (:import [com.opentable.db.postgres.embedded EmbeddedPostgres]
            [java.io File]))
 
+; Brevity doesn't yet do any connection pooling by default.  If you have a need for connection pooling, see:
+; https://github.com/luminus-framework/conman#using-bind-connection
 (def dbspec (environ/env :database-url))
 
 (hug/set-adapter! (adapters/kebab-adapter))
 
-(hug/def-db-fns "{{raw-name}}/sql/articles.sql")
-(hug/def-db-fns "{{raw-name}}/sql/users.sql")
+(conman/bind-connection dbspec "{{raw-name}}/sql/articles.sql")
+(conman/bind-connection dbspec "{{raw-name}}/sql/users.sql")
 
 (defn init! []
       (let [dev-mode? (= "true" (environ/env :dev-database))]

--- a/resources/leiningen/new/brevity/src/brevity/clj/roles/core.clj
+++ b/resources/leiningen/new/brevity/src/brevity/clj/roles/core.clj
@@ -28,12 +28,12 @@
 
 (defn token-auth [request token]
       ; TODO it's probably best to store the tokens hmac'd to guard against timing attacks
-      (when-let [session (sql/session-by-id sql/dbspec {:id token})]
+      (when-let [session (sql/session-by-id {:id token})]
                 (let [{:keys [since-started since-active]} session
                       expired? (>= since-started session-timeout)
                       inactive? (>= since-active idle-timeout)]
                      (when-not (or expired? inactive?)
-                               (sql/keep-session-active sql/dbspec {:id token})
+                               (sql/keep-session-active {:id token})
                                session))))
 
 (defn wrap-security [app]

--- a/resources/leiningen/new/brevity/src/brevity/clj/routes/account.clj
+++ b/resources/leiningen/new/brevity/src/brevity/clj/routes/account.clj
@@ -13,7 +13,7 @@
 
 (defn new-session-token [user-id]
       (let [token (random/base64 50)]
-           (sql/insert-session sql/dbspec {:id token :user-id user-id})
+           (sql/insert-session {:id token :user-id user-id})
            token))
 
 (defn verify-login [user password]
@@ -27,12 +27,12 @@
 ; TODO we'll want rate-limiting here
 (defn login [{:keys [body]}]
       (let [{:keys [email password]} body]
-           (if-let [user (sql/user-by-email sql/dbspec {:email email})]
+           (if-let [user (sql/user-by-email {:email email})]
                    (verify-login user password)
                    (fail-with-dummy-hash))))
 
 (defn logout [{:keys [identity]}]
-      (sql/delete-session sql/dbspec {:id (:session-id identity)})
+      (sql/delete-session {:id (:session-id identity)})
       {:status 200})
 
 (defn get-account-info [{:keys [identity]}]

--- a/resources/leiningen/new/brevity/src/brevity/clj/routes/blog.clj
+++ b/resources/leiningen/new/brevity/src/brevity/clj/routes/blog.clj
@@ -8,7 +8,7 @@
           (s/rename-keys {:article-id :id})))
 
 (defn blog-entries [req]
-      (let [articles (sql/all-articles sql/dbspec)]
+      (let [articles (sql/all-articles)]
            {:status 200
             :body   (map public-view articles)}))
 
@@ -16,13 +16,13 @@
       (let [{:keys [id]} route-params
             parsed-id (try (Long/parseLong id)
                            (catch NumberFormatException e -1))]
-           (if-let [article (sql/article-by-id sql/dbspec {:id parsed-id})]
+           (if-let [article (sql/article-by-id {:id parsed-id})]
                    {:status 200
                     :body (public-view article)}
                    {:status 404})))
 
 (defn new-blog-entry [{:keys [body]}]
-      (let [article (sql/insert-article sql/dbspec (select-keys body [:title :content]))]
+      (let [article (sql/insert-article (select-keys body [:title :content]))]
            {:status 200
             :body article}))
 
@@ -30,5 +30,5 @@
       (let [{:keys [id]} route-params
             parsed-id (try (Long/parseLong id)
                            (catch NumberFormatException e -1))]
-           (sql/delete-article sql/dbspec {:id parsed-id})
+           (sql/delete-article {:id parsed-id})
            {:status 200}))

--- a/resources/leiningen/new/brevity/tool-src/brevity/core.clj
+++ b/resources/leiningen/new/brevity/tool-src/brevity/core.clj
@@ -34,7 +34,7 @@
   {:store :database
    ; The migration dir is relative to /resources, so .sql files will be dropped in resources/private/migrations.
    :migration-dir "private/migrations"
-   :db sql/dbspec})
+   :db {:connection-uri sql/connection-uri}})
 
 (defn migrate-new [[migration-name]]
       (println "Creating up.sql and down.sql for" migration-name "in" (:migration-dir migratus-spec))


### PR DESCRIPTION
[Conman](https://github.com/luminus-framework/conman) keeps us from having to repeat `sql/dbspec` in all of our database calls, while also providing some nice stuff for connection pooling later on.